### PR TITLE
Alternative approach for PR 24489

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -16,10 +16,6 @@
  */
 package org.apache.spark.sql.internal
 
-import scala.collection.JavaConverters._
-
-import org.apache.hadoop.conf.Configuration
-
 import org.apache.spark.SparkConf
 import org.apache.spark.annotation.{Experimental, Unstable}
 import org.apache.spark.sql.{ExperimentalMethods, SparkSession, UDFRegistration, _}
@@ -83,17 +79,6 @@ abstract class BaseSessionStateBuilder(
   }
 
   /**
-   * This hadoopConf contains user settings in Hadoop's core-site.xml file
-   * and Hive's hive-site.xml file. Note, we load hive-site.xml file manually in
-   * SharedState and put settings in this hadoopConf
-   */
-  private def mergeHadoopConf(conf: SQLConf, hadoopConf: Configuration): Unit = {
-    (hadoopConf.iterator().asScala.map(kv => kv.getKey -> kv.getValue)).foreach {
-      case (k, v) => conf.setConfString(k, v)
-    }
-  }
-
-  /**
    * SQL-specific key-value configurations.
    *
    * These either get cloned from a pre-existing instance or newly created. The conf is merged
@@ -103,7 +88,6 @@ abstract class BaseSessionStateBuilder(
     parentState.map(_.conf.clone()).getOrElse {
       val conf = new SQLConf
       mergeSparkConf(conf, session.sparkContext.conf)
-      mergeHadoopConf(conf, session.sparkContext.hadoopConfiguration)
       conf
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.internal
 
 import java.util.Locale
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat
 
 case class HiveSerDe(
@@ -88,7 +89,17 @@ object HiveSerDe {
   }
 
   def getDefaultStorage(conf: SQLConf): CatalogStorageFormat = {
-    val defaultStorageType = conf.getConfString("hive.default.fileformat", "textfile")
+    // To respect hive-site.xml, it peeks Hadoop configuration from existing Spark session,
+    // as an easy workaround. See SPARK-27555.
+    val defaultFormatKey = "hive.default.fileformat"
+    val defaultValue = {
+      val defaultFormatValue = "textfile"
+      SparkSession.getActiveSession.map { session =>
+        session.sessionState.newHadoopConf().get(defaultFormatKey, defaultFormatValue)
+      }.getOrElse(defaultFormatValue)
+    }
+
+    val defaultStorageType = conf.getConfString(defaultFormatKey, defaultValue)
     val defaultHiveSerde = sourceToSerDe(defaultStorageType)
     CatalogStorageFormat.empty.copy(
       inputFormat = defaultHiveSerde.flatMap(_.inputFormat)


### PR DESCRIPTION
Alternative approach of https://github.com/apache/spark/pull/24489 to get Hive default fileformat from Hadoop configuration.
